### PR TITLE
Use index layout for index page

### DIFF
--- a/docs/src/hugo/content/index.md
+++ b/docs/src/hugo/content/index.md
@@ -1,5 +1,6 @@
+
 +++
-layout = "single"
+layout = "index"
 title  = "Home"
 +++
 


### PR DESCRIPTION
Renders the index page correctly for me on hugo-0.22.1.