### PR TITLE
releasePublishArtifactsAction should publish Docker image

### DIFF
--- a/http/build.sbt
+++ b/http/build.sbt
@@ -41,6 +41,8 @@ publishLocal := (publishLocal in Docker).value
 
 publish := (publish in Docker).value
 
+releasePublishArtifactsAction := publish.value
+
 custom.resources
 
 custom.revolver


### PR DESCRIPTION
It's defaults to `publishSigned`, which is still publishing to Maven.  We want to just execute the `publish` step (same as sbt-release's default) in the http module in order to publish to the Docker registry.