### PR TITLE
Test new rig for publishing jars to Maven Central

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("io.get-coursier"   % "sbt-coursier"    % "1.0.0-M15-1")
 
 addSbtPlugin("io.spray"          % "sbt-revolver"    % "0.7.2")
 
-addSbtPlugin("io.verizon.build"  % "sbt-rig"         % "3.0.33")
+addSbtPlugin("io.verizon.build"  % "sbt-rig"         % "3.0.34")
 
 addSbtPlugin("org.brianmckenna"  % "sbt-wartremover" % "0.14")
 


### PR DESCRIPTION
This contains a downgrade of sbt-release, which was a working version on older
versions of rig. Let's see if this automates the release of jars to Maven
Central.