### PR TITLE
Clean up install script output, fix interpreter

### DIFF
--- a/bin/generate-keys
+++ b/bin/generate-keys
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function gen {
   dd if=/dev/urandom bs=16 count=1 2>/dev/null | base64

--- a/bin/generate-token
+++ b/bin/generate-token
@@ -34,6 +34,7 @@ fi
 if [ -z "$GITHUB_PASSWORD" ]; then
   prompt "GitHub password"
   read -s GITHUB_PASSWORD
+  echo
   ensure_param "GitHub password" $GITHUB_PASSWORD
 else
   echo "Detected your GitHub access token from your shell GITHUB_PASSWORD variable..."
@@ -50,6 +51,7 @@ fi
 if [ -z "$GITHUB_APP_SECRET" ]; then
   prompt "GitHub application secret"
   read -s GITHUB_APP_SECRET
+  echo
   ensure_param "GitHub application secret" $GITHUB_APP_SECRET
 else
   echo "Detected your GitHub access token from your shell GITHUB_APP_SECRET variable..."


### PR DESCRIPTION
- Clean up the output of the install script to prevent prompts from printing on the same line
- Change the interpreter in the generate-keys script to prevent an error when trying to run with ./