### PR TITLE
Add a catch for empty string during pagination

### DIFF
--- a/core/src/main/scala/Github.scala
+++ b/core/src/main/scala/Github.scala
@@ -368,14 +368,16 @@ object Github {
       * for splitting the github links header output
       */
       private[nelson] def tuplize(in: String): Option[(Step, URI)] = {
-        val Array(uri,rel) = in.split(";")
-        val linkr = "<(.*)>".r
-        val relr  = "rel=\"(.*)\"".r
+        if (in != "") {
+          val Array(uri,rel) = in.split(";")
+          val linkr = "<(.*)>".r
+          val relr  = "rel=\"(.*)\"".r
 
-        val ouri = linkr.replaceFirstIn(uri, "$1").trim
-        val orel = relr.replaceFirstIn(rel, "$1").trim
+          val ouri = linkr.replaceFirstIn(uri, "$1").trim
+          val orel = relr.replaceFirstIn(rel, "$1").trim
 
-        Step.fromString(orel).map(_ -> new URI(ouri))
+          Step.fromString(orel).map(_ -> new URI(ouri))
+        } else None
       }
     }
 


### PR DESCRIPTION
Prevents tuplize function from erroring during pagination when repos do not extend to multiple pages, and the empty string is passed to the tuplize function.