### PR TITLE
fix stackoverflow error when constructing graph 

### DIFF
--- a/core/src/main/scala/Datacenter.scala
+++ b/core/src/main/scala/Datacenter.scala
@@ -259,13 +259,15 @@ object Datacenter {
 
   final case class LoadbalancerDeployment(
     id: ID,
-    nsid: ID,
+    namespace: Namespace,
     hash: String,
     loadbalancer: DCLoadbalancer,
     deployTime: Instant,
     guid: GUID,
     address: String
   ) {
+
+    def nsid: ID = namespace.id
 
     // because loadbalancers are bound by major version, the version portion of a
     // loadbalancer StackName is always the min version, i.e. 1.0.0 or 2.0.0

--- a/core/src/main/scala/routing/package.scala
+++ b/core/src/main/scala/routing/package.scala
@@ -18,7 +18,8 @@ package nelson
 
 package object routing {
   import storage._
-  import scalaz.{==>>, ~>, Monad,Monoid,NonEmptyList,RWST,Traverse,\/}
+  import scalaz.{==>>, ~>, Monad,Monoid,NonEmptyList,RWST,Traverse,\/, Id}
+  import scalaz.Id._
   import scalaz.std.list._
   import scalaz.std.option._
   import scalaz.std.anyVal._
@@ -56,12 +57,12 @@ package object routing {
   type DiscoveryTables = NamespaceName ==>> DiscoveryTable
 
   // this just gets our monad in the the expected * → * shape
-  type GraphBuild[A] = RWST[StoreOpF,RoutingTables,List[String],RoutingGraph,A]
+  type GraphBuild[A] = RWST[Id,RoutingTables,List[String],RoutingGraph,A]
 
   // this is the type we pass to liftM to lift a task into our RWST
   type GraphBuildT[F[_],A] = RWST[F,RoutingTables,List[String],RoutingGraph,A]
 
   // this is a value which has all of the MonadReader (ask),
   // MonadState (get,put,modify) syntax for our RWST
-  val graphBuild = RWST.rwstMonad[StoreOpF,RoutingTables,List[String],RoutingGraph]
+  val graphBuild = RWST.rwstMonad[Id,RoutingTables,List[String],RoutingGraph]
 }

--- a/core/src/main/scala/storage/h2.scala
+++ b/core/src/main/scala/storage/h2.scala
@@ -1464,11 +1464,11 @@ final case class H2Storage(xa: Transactor[Task]) extends (StoreOp ~> Task) {
     } yield DCLoadbalancer(lb._1, lb._2, lb._3, rt)).run
   }
 
-  private def loadbalancerRowToDeployment(lb: LoadbalancerRow): ConnectionIO[LoadbalancerDeployment] = {
-    getLoadbalancerRoutes(lb._4).map(rt =>
-      LoadbalancerDeployment(lb._1, lb._2, lb._3,
-        DCLoadbalancer(lb._4, lb._5, lb._6, rt), lb._7, lb._8, lb._9))
-  }
+  private def loadbalancerRowToDeployment(lb: LoadbalancerRow): ConnectionIO[LoadbalancerDeployment] =
+    for {
+      ns <- getNamespaceByID(lb._2)
+      rt <- getLoadbalancerRoutes(lb._4)
+    } yield LoadbalancerDeployment(lb._1, ns, lb._3, DCLoadbalancer(lb._4, lb._5, lb._6, rt), lb._7, lb._8, lb._9)
 
   def findLoadbalancerDeployment(name: String, v: MajorVersion, nsid: ID): ConnectionIO[Option[LoadbalancerDeployment]] = {
     val query: ConnectionIO[Option[LoadbalancerRow]] = sql"""

--- a/core/src/test/scala/ExpirationPolicySpec.scala
+++ b/core/src/test/scala/ExpirationPolicySpec.scala
@@ -402,7 +402,7 @@ class ExpirationPolicySpec extends NelsonSuite with BeforeAndAfterEach with Prop
 
   it should "retain all active versions when a loadbalancer depends on deployment" in {
 
-    val lb = LoadbalancerDeployment(0L, 0L, "hash",
+    val lb = LoadbalancerDeployment(0L, Datacenter.Namespace(0L, NamespaceName("dev"), "dc"), "hash",
       DCLoadbalancer(0L,"lb",MajorVersion(1),Vector()), Instant.now(), "guid", "dns")
 
     val job310 = makeDeployment(1L, "job", Version(3,1,0), RetainActive)

--- a/core/src/test/scala/LoadbalancerSpec.scala
+++ b/core/src/test/scala/LoadbalancerSpec.scala
@@ -31,14 +31,15 @@ class LoadbalancerSpec extends FlatSpec with Matchers with RoutingFixtures {
 
   val dc = datacenter("name")
 
+  val namespace = Datacenter.Namespace(1L, NamespaceName("devel"), "dc")
+
   private def makeDeployment(id: ID, name: String, version: Version, ps: Set[Port]) = {
-    val namespace = Datacenter.Namespace(1L, NamespaceName("devel"), "dc")
     val dc = DCUnit(id,name,version,"",Set.empty,Set.empty,ps)
     Deployment(id,dc,"foo",namespace,NOW,"quasar","plan","guid","retain-latest")
   }
 
   private def makeLoadbalancer(id: ID, name: String, version: MajorVersion, routes: Vector[Manifest.Route]) =
-    LoadbalancerDeployment(id, 0L, "hash", DCLoadbalancer(id, name, version, routes), NOW, "guid", "dns")
+    LoadbalancerDeployment(id, namespace, "hash", DCLoadbalancer(id, name, version, routes), NOW, "guid", "dns")
 
   private def makeRoute(ref: String, port: Int, d: Deployment, portName: String): Route = {
     Route(Manifest.Port(ref,port,""),


### PR DESCRIPTION
`Free.flatMap` is not stacksafe in the version of scalaz that we use. When constructing a routing graph the only time we use a `StoreOpF` is to get the namespace for a loadbalancer. All other calls to StoreOpF are outside the GraphBuild RWST. So the fix for this was to include the namespace on the loadbalancer datatype (just like we do for regular deployments) and use a stacksafe monad.