### PR TITLE
cleanup process only applies expiration policy to routable deployments

### DIFF
--- a/core/src/main/scala/cleanup/ExpirationPolicy.scala
+++ b/core/src/main/scala/cleanup/ExpirationPolicy.scala
@@ -209,11 +209,11 @@ object ExpirationPolicyProcess {
       .map(_ => d.copy(exp = Some(i)))
   }
 
-  def expirationProcess(cfg: NelsonConfig): Channel[Task,(Datacenter,Namespace,DeploymentCtx,RoutingGraph),(Datacenter,Namespace,DeploymentCtx)] =
+  def expirationProcess(cfg: NelsonConfig): Channel[Task, CleanupRow, CleanupRow] =
     channel.lift { case (dc, ns, d, graph) =>
       applyPolicyToDeployment(d, graph)(cfg.cleanup.extendTTL)
-        .map(ext => runs(cfg.storage, updateExpiration(d,ext)).map(d => (dc,ns,d)))
-        .getOrElse(Task.now((dc,ns,d)))
+        .map(ext => runs(cfg.storage, updateExpiration(d,ext)).map(d => (dc,ns,d,graph)))
+        .getOrElse(Task.now((dc,ns,d,graph)))
     }
 }
 

--- a/core/src/main/scala/cleanup/GarbageCollector.scala
+++ b/core/src/main/scala/cleanup/GarbageCollector.scala
@@ -51,11 +51,11 @@ object GarbageCollector {
    * against the case where the ExpirationPolicy process fails
    * and GC eagerly marks deployments that it shouldn't.
    */
-  def mark(cfg: NelsonConfig): Channel[Task,(Datacenter,Namespace,DeploymentCtx),(Datacenter,Namespace,Deployment)] = {
+  def mark(cfg: NelsonConfig): Channel[Task, CleanupRow, CleanupRow] = {
     import Json._
     import audit.AuditableInstances._
-    channel.lift { case (dc, ns, d) =>
-      runs(cfg.storage, markAsGarbage(d.deployment).map(d => (dc, ns, d))) <*
+    channel.lift { case (dc, ns, d, gr) =>
+      runs(cfg.storage, markAsGarbage(d.deployment).map(_ => (dc, ns, d, gr))) <*
         cfg.auditor.write(d.deployment, audit.GarbageAction)
     }
   }

--- a/core/src/main/scala/cleanup/Reaper.scala
+++ b/core/src/main/scala/cleanup/Reaper.scala
@@ -40,9 +40,9 @@ object Reaper {
    * scheduler was used to initially place the deployment
    * to delete the running job.
    */
-  def reap(cfg: NelsonConfig): Sink[Task, (Datacenter,Namespace,Deployment)] =
-    sink.lift { case (dc, ns, d) =>
-      destroy(dc,ns,d)(dc.workflow)(cfg)
+  def reap(cfg: NelsonConfig): Sink[Task, CleanupRow] =
+    sink.lift { case (dc, ns, d, gr) =>
+      destroy(dc,ns,d.deployment)(dc.workflow)(cfg)
         .map { _ => destroySuccessCounter.labels(ns.name.asString).inc() }
         .handleWith {
           // this is a Sink and the end of the world, so we need to handle NonFatal to keep Processes running

--- a/core/src/main/scala/cleanup/package.scala
+++ b/core/src/main/scala/cleanup/package.scala
@@ -1,0 +1,24 @@
+//: ----------------------------------------------------------------------------
+//: Copyright (C) 2017 Verizon.  All Rights Reserved.
+//:
+//:   Licensed under the Apache License, Version 2.0 (the "License");
+//:   you may not use this file except in compliance with the License.
+//:   You may obtain a copy of the License at
+//:
+//:       http://www.apache.org/licenses/LICENSE-2.0
+//:
+//:   Unless required by applicable law or agreed to in writing, software
+//:   distributed under the License is distributed on an "AS IS" BASIS,
+//:   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//:   See the License for the specific language governing permissions and
+//:   limitations under the License.
+//:
+//: ----------------------------------------------------------------------------
+package nelson
+
+package object cleanup {
+  import Datacenter.Namespace
+  import routing.RoutingGraph
+
+  type CleanupRow = (Datacenter, Namespace, DeploymentCtx, RoutingGraph) 
+}


### PR DESCRIPTION
Deployments can get orphaned in a couple of corner cases. This PR addresses this by only applying the expiration policy to routable deployments. By doing this we only allow routable deployments the change to extend their lease. All other deployments (including orphans) will naturally expire and get cleaned up.